### PR TITLE
drtrigon/tests: Enhance testing and statistics by complexity, time and memory analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
 
 script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
+  - radon mi setup.py setupdeps.py file_metadata tests
   - python -m pytest --cov --durations=20 --pastebin=failed --mccabe ;
   - python setup.py sdist bdist bdist_wheel
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
 
 script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
-  - python -m pytest --cov --durations=20 --pastebin=failed ;
+  - python -m pytest --cov --durations=20 --pastebin=failed --mccabe ;
   - python setup.py sdist bdist bdist_wheel
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,8 @@ script:
   # complexity (--mccabe) and time (--profile, --durations) analysis by pytest
   # are too simplistic and buggy currently
   - python -m pytest --cov --pastebin=failed ;
-  - python -m cProfile -s time $(which py.test) ;
-  - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out
+  - python -m cProfile -s time $(which py.test) > profile.out && head profile.out -n 50 ;
+  - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out | head -n 50
   - python setup.py sdist bdist bdist_wheel
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - ffmpeg
       - libmagickwand-dev
       - libzbar-dev
+      - valgrind
 
 before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -61,6 +62,7 @@ script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
   - radon mi setup.py setupdeps.py file_metadata tests
   - python -m pytest --cov --durations=20 --pastebin=failed --mccabe ;
+  - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest && cat valgrind.log && ms_print massif.out
   - python setup.py sdist bdist bdist_wheel
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
   - ls -l file_metadata/datafiles
 
 script:
-  - flake8 setup.py setupdeps.py file_metadata tests
+  - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
   - python -m pytest --cov ;
   - python setup.py sdist bdist bdist_wheel
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
   - radon mi setup.py setupdeps.py file_metadata tests
-  - python -m pytest --cov --durations=20 --pastebin=failed --mccabe ;
+  - python -m pytest --cov --durations=20 --pastebin=failed ;
   - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out
   - python setup.py sdist bdist bdist_wheel
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ script:
   # complexity (--mccabe) and time (--profile, --durations) analysis by pytest
   # are too simplistic and buggy currently
   - python -m pytest --cov --pastebin=failed ;
+  - pprofile $(which py.test) ;
   - python -m cProfile -s time $(which py.test) > profile.out && head profile.out -n 50 ;
   - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out | head -n 50
   - python setup.py sdist bdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
 
 script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
-  - python -m pytest --cov ;
+  - python -m pytest --cov --durations=20 --pastebin=failed ;
   - python setup.py sdist bdist bdist_wheel
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
   # complexity (--mccabe) and time (--profile, --durations) analysis by pytest
   # are too simplistic and buggy currently
   - python -m pytest --cov --pastebin=failed ;
-  - pprofile $(which py.test) ;
+  # - pprofile $(which py.test) ;
   - python -m cProfile -s time $(which py.test) > profile.out && head profile.out -n 50 ;
   - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out | head -n 50
   - python setup.py sdist bdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
   - radon mi setup.py setupdeps.py file_metadata tests
   - python -m pytest --cov --durations=20 --pastebin=failed --mccabe ;
-  - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest && cat valgrind.log && ms_print massif.out
+  - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out
   - python setup.py sdist bdist bdist_wheel
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,10 @@ install:
 script:
   - flake8 --verbose --show-source --statistics --benchmark --max-complexity 10 setup.py setupdeps.py file_metadata tests
   - radon mi setup.py setupdeps.py file_metadata tests
-  - python -m pytest --cov --durations=20 --pastebin=failed ;
+  # complexity (--mccabe) and time (--profile, --durations) analysis by pytest
+  # are too simplistic and buggy currently
+  - python -m pytest --cov --pastebin=failed ;
+  - python -m cProfile -s time $(which py.test) ;
   - valgrind --tool=massif --massif-out-file=massif.out --log-file=valgrind.log python -m pytest || cat valgrind.log && ms_print massif.out
   - python setup.py sdist bdist bdist_wheel
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,5 +15,4 @@ flake8-string-format
 pep8-naming
 pep257
 flake8-future-import
-pytest-mccabe
 radon

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ pep8-naming
 pep257
 flake8-future-import
 pytest-mccabe
+radon

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,3 +15,4 @@ flake8-string-format
 pep8-naming
 pep257
 flake8-future-import
+pytest-mccabe

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ pep8-naming
 pep257
 flake8-future-import
 radon
+pprofile

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,4 +16,3 @@ pep8-naming
 pep257
 flake8-future-import
 radon
-pprofile


### PR DESCRIPTION
Enhance pytest output by adding some basic time profiling and mccabe complexity test, also post errors fund to bpaste.net. Enhance flake8 output by adding complexity test and more verbosity. Add valgrind massif memory usage test for pytest unittests. And finally add radon Maintainability Index calculation.

This set will cause travis build errors due to the complexity analysis with the current code will fail.

Solves issues https://github.com/pywikibot-catfiles/file-metadata/issues/69, https://github.com/pywikibot-catfiles/file-metadata/issues/73 and https://github.com/pywikibot-catfiles/file-metadata/issues/74.
