### PR TITLE
Skip UnicodeDecode Exceptions

### DIFF
--- a/file_metadata/generic_file.py
+++ b/file_metadata/generic_file.py
@@ -124,7 +124,10 @@ class GenericFile(object):
         methods = methods or sorted(dir(self))
         for method in methods:
             if method.startswith(prefix) and method.endswith(suffix):
-                data.update(getattr(self, method)())
+		try:
+			data.update(getattr(self, method)())
+		except UnicodeDecodeError:
+			pass
         return data
 
     @memoized


### PR DESCRIPTION
Traceback (most recent call last):
File "", line 1, in 
File "/usr/local/lib/python2.7/dist-packages/file_metadata/generic_file.py", line 127, in analyze
data.update(getattr(self, method)())
File "/usr/local/lib/python2.7/dist-packages/file_metadata/image/image_file.py", line 741, in analyze_barcode_zxing
if 'java.io.IOException: Could not load file' in err.output:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 149: ordinal not in range(128)

This occurs after loading a jpg file with an accidental encrypted 2d barcode (I wanted to .analyze() all the info I can but keep getting stopped by analyze_barcode_zxing)

This is a bug-skip suggestion for the generic_file method to bypass the aforementioned exception (should be any other similar error for maximum possible results)